### PR TITLE
Add option to honor grid to raytracing

### DIFF
--- a/fteikpy/_fteik/_common.py
+++ b/fteikpy/_fteik/_common.py
@@ -19,7 +19,7 @@ def shrink(pcur, delta, lower, upper):
     tmp = pcur - delta
     maskl = tmp < lower
     masku = tmp > upper
-    
+
     if maskl.any():
         return numpy.min((pcur[maskl] - lower[maskl]) / delta[maskl])
 

--- a/fteikpy/_fteik/_common.py
+++ b/fteikpy/_fteik/_common.py
@@ -3,6 +3,16 @@ import numpy
 from .._common import jitted
 
 
+@jitted
+def first_index(x, y):
+    """Find index of first occurrence of x in array y."""
+    for i, v in enumerate(y):
+        if numpy.array_equal(v, x):
+            return i
+
+    return -1
+
+
 @jitted("f8(f8[:], f8[:], f8[:], f8[:])")
 def shrink(pcur, delta, lower, upper):
     """Stepsize shrinking factor if ray crosses interface."""

--- a/fteikpy/_fteik/_common.py
+++ b/fteikpy/_fteik/_common.py
@@ -1,0 +1,20 @@
+import numpy
+
+from .._common import jitted
+
+
+@jitted("f8(f8[:], f8[:], f8[:], f8[:])")
+def shrink(pcur, delta, lower, upper):
+    """Stepsize shrinking factor if ray crosses interface."""
+    tmp = pcur - delta
+    maskl = tmp < lower
+    masku = tmp > upper
+    
+    if maskl.any():
+        return numpy.min((pcur[maskl] - lower[maskl]) / delta[maskl])
+
+    elif masku.any():
+        return numpy.min((pcur[masku] - upper[masku]) / delta[masku])
+
+    else:
+        return 1.0

--- a/fteikpy/_fteik/_ray2d.py
+++ b/fteikpy/_fteik/_ray2d.py
@@ -1,19 +1,31 @@
 import numpy
 from numba import prange
 
+from ._common import shrink
 from .._common import dist2d, jitted, norm2d
 from .._interp import interp2d
 
 
-@jitted("f8[:, :](f8[:], f8[:], f8[:, :], f8[:, :],f8, f8, f8, f8, f8)")
-def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize):
+@jitted("f8[:, :](f8[:], f8[:], f8[:, :], f8[:, :], f8, f8, f8, f8, f8, b1)")
+def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid):
     """Perform a posteriori 2D ray-tracing."""
     condz = z[0] <= zend <= z[-1]
     condx = x[0] <= xend <= x[-1]
     if not (condz and condx):
         raise ValueError("end point out of bound")
 
+    if honor_grid:
+        nz, nx = len(z), len(x)
+
+        i = numpy.nonzero(z <= zend)[0][-1]
+        j = numpy.nonzero(x <= xend)[0][-1]
+        zmin = z[max(i - 1, 0)] if zend == z[i] else z[i]
+        xmin = x[max(j - 1, 0)] if xend == x[j] else x[j]
+        lower = numpy.array([zmin, xmin])
+        upper = numpy.array([z[min(i + 1, nz - 1)], x[min(j + 1, nx - 1)]])
+
     pcur = numpy.array([zend, xend], dtype=numpy.float64)
+    delta = numpy.empty(2, dtype=numpy.float64)
     ray = [pcur.copy()]
     while dist2d(zsrc, xsrc, pcur[0], pcur[1]) > stepsize:
         gz = interp2d(z, x, zgrad, pcur)
@@ -25,11 +37,28 @@ def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize):
         else:
             break
 
-        pcur[0] -= stepsize * gz * gni
-        pcur[1] -= stepsize * gx * gni
-        ray.append(pcur.copy())
-    ray.append(numpy.array([zsrc, xsrc], dtype=numpy.float64))
+        delta[0] = stepsize * gz * gni
+        delta[1] = stepsize * gx * gni
 
+        if honor_grid:
+            fac = shrink(pcur, delta, lower, upper)
+            pcur -= fac * delta
+
+            if fac < 1.0:
+                i = numpy.nonzero(z <= pcur[0])[0][-1]
+                j = numpy.nonzero(x <= pcur[1])[0][-1]
+                lower[0] = z[max(i - 1, 0)] if pcur[0] == z[i] else z[i]
+                lower[1] = x[max(j - 1, 0)] if pcur[1] == x[j] else x[j]
+                upper[0] = z[i + 1]
+                upper[1] = x[j + 1]
+
+                ray.append(pcur.copy())
+
+        else:
+            pcur -= delta
+            ray.append(pcur.copy())
+
+    ray.append(numpy.array([zsrc, xsrc], dtype=numpy.float64))
     out = numpy.empty((len(ray), 2), dtype=numpy.float64)
     for i, r in enumerate(ray):
         out[-i - 1] = r
@@ -38,22 +67,22 @@ def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize):
 
 
 @jitted(parallel=True)
-def _ray2d_vectorized(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize):
+def _ray2d_vectorized(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid=False):
     """Perform ray-tracing in parallel for different points."""
     out = []
     for i in prange(len(zend)):
-        out.append(_ray2d(z, x, zgrad, xgrad, zend[i], xend[i], zsrc, xsrc, stepsize))
+        out.append(_ray2d(z, x, zgrad, xgrad, zend[i], xend[i], zsrc, xsrc, stepsize, honor_grid))
 
     return out
 
 
 @jitted
-def ray2d(z, x, zgrad, xgrad, p, src, stepsize):
+def ray2d(z, x, zgrad, xgrad, p, src, stepsize, honor_grid=False):
     """Perform ray-tracing."""
     if p.ndim == 1:
-        return _ray2d(z, x, zgrad, xgrad, p[0], p[1], src[0], src[1], stepsize)
+        return _ray2d(z, x, zgrad, xgrad, p[0], p[1], src[0], src[1], stepsize, honor_grid)
 
     else:
         return _ray2d_vectorized(
-            z, x, zgrad, xgrad, p[:, 0], p[:, 1], src[0], src[1], stepsize
+            z, x, zgrad, xgrad, p[:, 0], p[:, 1], src[0], src[1], stepsize, honor_grid,
         )

--- a/fteikpy/_fteik/_ray2d.py
+++ b/fteikpy/_fteik/_ray2d.py
@@ -17,8 +17,8 @@ def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid):
     if honor_grid:
         nz, nx = len(z), len(x)
 
-        i = numpy.nonzero(z <= zend)[0][-1]
-        j = numpy.nonzero(x <= xend)[0][-1]
+        i = numpy.searchsorted(z, zend, side="right") - 1
+        j = numpy.searchsorted(x, xend, side="right") - 1
         zmin = z[max(i - 1, 0)] if zend == z[i] else z[i]
         xmin = x[max(j - 1, 0)] if xend == x[j] else x[j]
         lower = numpy.array([zmin, xmin])
@@ -45,8 +45,8 @@ def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid):
             pcur -= fac * delta
 
             if fac < 1.0:
-                i = numpy.nonzero(z <= pcur[0])[0][-1]
-                j = numpy.nonzero(x <= pcur[1])[0][-1]
+                i = numpy.searchsorted(z, pcur[0], side="right") - 1
+                j = numpy.searchsorted(x, pcur[1], side="right") - 1
                 lower[0] = z[max(i - 1, 0)] if pcur[0] == z[i] else z[i]
                 lower[1] = x[max(j - 1, 0)] if pcur[1] == x[j] else x[j]
                 upper[0] = z[i + 1]

--- a/fteikpy/_fteik/_ray2d.py
+++ b/fteikpy/_fteik/_ray2d.py
@@ -1,7 +1,7 @@
 import numpy
 from numba import prange
 
-from ._common import shrink
+from ._common import first_index, shrink
 from .._common import dist2d, jitted, norm2d
 from .._interp import interp2d
 
@@ -83,6 +83,12 @@ def ray2d(z, x, zgrad, xgrad, p, src, stepsize, honor_grid=False):
         return _ray2d(z, x, zgrad, xgrad, p[0], p[1], src[0], src[1], stepsize, honor_grid)
 
     else:
-        return _ray2d_vectorized(
+        rays = _ray2d_vectorized(
             z, x, zgrad, xgrad, p[:, 0], p[:, 1], src[0], src[1], stepsize, honor_grid,
         )
+
+        # Hack: append does not work in parallel, sort back list
+        end_points = [ray[-1] for ray in rays]
+        idx = [first_index(x, end_points) for x in p]
+
+        return [rays[i] for i in idx]

--- a/fteikpy/_fteik/_ray2d.py
+++ b/fteikpy/_fteik/_ray2d.py
@@ -1,9 +1,9 @@
 import numpy
 from numba import prange
 
-from ._common import first_index, shrink
 from .._common import dist2d, jitted, norm2d
 from .._interp import interp2d
+from ._common import first_index, shrink
 
 
 @jitted("f8[:, :](f8[:], f8[:], f8[:, :], f8[:, :], f8, f8, f8, f8, f8, b1)")
@@ -67,11 +67,17 @@ def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid):
 
 
 @jitted(parallel=True)
-def _ray2d_vectorized(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid=False):
+def _ray2d_vectorized(
+    z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid=False
+):
     """Perform ray-tracing in parallel for different points."""
     out = []
     for i in prange(len(zend)):
-        out.append(_ray2d(z, x, zgrad, xgrad, zend[i], xend[i], zsrc, xsrc, stepsize, honor_grid))
+        out.append(
+            _ray2d(
+                z, x, zgrad, xgrad, zend[i], xend[i], zsrc, xsrc, stepsize, honor_grid
+            )
+        )
 
     return out
 
@@ -80,11 +86,22 @@ def _ray2d_vectorized(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, hono
 def ray2d(z, x, zgrad, xgrad, p, src, stepsize, honor_grid=False):
     """Perform ray-tracing."""
     if p.ndim == 1:
-        return _ray2d(z, x, zgrad, xgrad, p[0], p[1], src[0], src[1], stepsize, honor_grid)
+        return _ray2d(
+            z, x, zgrad, xgrad, p[0], p[1], src[0], src[1], stepsize, honor_grid
+        )
 
     else:
         rays = _ray2d_vectorized(
-            z, x, zgrad, xgrad, p[:, 0], p[:, 1], src[0], src[1], stepsize, honor_grid,
+            z,
+            x,
+            zgrad,
+            xgrad,
+            p[:, 0],
+            p[:, 1],
+            src[0],
+            src[1],
+            stepsize,
+            honor_grid,
         )
 
         # Hack: append does not work in parallel, sort back list

--- a/fteikpy/_fteik/_ray3d.py
+++ b/fteikpy/_fteik/_ray3d.py
@@ -1,7 +1,7 @@
 import numpy
 from numba import prange
 
-from ._common import shrink
+from ._common import first_index, shrink
 from .._common import dist3d, jitted, norm3d
 from .._interp import interp3d
 
@@ -127,7 +127,7 @@ def ray3d(z, x, y, zgrad, xgrad, ygrad, p, src, stepsize, honor_grid=False):
         )
 
     else:
-        return _ray3d_vectorized(
+        rays = _ray3d_vectorized(
             z,
             x,
             y,
@@ -143,3 +143,9 @@ def ray3d(z, x, y, zgrad, xgrad, ygrad, p, src, stepsize, honor_grid=False):
             stepsize,
             honor_grid,
         )
+
+        # Hack: append does not work in parallel, sort back list
+        end_points = [ray[-1] for ray in rays]
+        idx = [first_index(x, end_points) for x in p]
+
+        return [rays[i] for i in idx]

--- a/fteikpy/_fteik/_ray3d.py
+++ b/fteikpy/_fteik/_ray3d.py
@@ -20,9 +20,9 @@ def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, ste
     if honor_grid:
         nz, nx, ny = len(z), len(x), len(y)
 
-        i = numpy.nonzero(z <= zend)[0][-1]
-        j = numpy.nonzero(x <= xend)[0][-1]
-        k = numpy.nonzero(y <= yend)[0][-1]
+        i = numpy.searchsorted(z, zend, side="right") - 1
+        j = numpy.searchsorted(x, xend, side="right") - 1
+        k = numpy.searchsorted(y, yend, side="right") - 1
         zmin = z[max(i - 1, 0)] if zend == z[i] else z[i]
         xmin = x[max(j - 1, 0)] if xend == x[j] else x[j]
         ymin = y[max(k - 1, 0)] if yend == y[k] else y[k]
@@ -52,9 +52,9 @@ def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, ste
             pcur -= fac * delta
 
             if fac < 1.0:
-                i = numpy.nonzero(z <= pcur[0])[0][-1]
-                j = numpy.nonzero(x <= pcur[1])[0][-1]
-                k = numpy.nonzero(y <= pcur[2])[0][-1]
+                i = numpy.searchsorted(z, pcur[0], side="right") - 1
+                j = numpy.searchsorted(x, pcur[1], side="right") - 1
+                k = numpy.searchsorted(y, pcur[2], side="right") - 1
                 lower[0] = z[max(i - 1, 0)] if pcur[0] == z[i] else z[i]
                 lower[1] = x[max(j - 1, 0)] if pcur[1] == x[j] else x[j]
                 lower[2] = y[max(k - 1, 0)] if pcur[2] == y[k] else y[k]

--- a/fteikpy/_fteik/_ray3d.py
+++ b/fteikpy/_fteik/_ray3d.py
@@ -1,14 +1,15 @@
 import numpy
 from numba import prange
 
+from ._common import shrink
 from .._common import dist3d, jitted, norm3d
 from .._interp import interp3d
 
 
 @jitted(
-    "f8[:, :](f8[:], f8[:], f8[:], f8[:, :, :], f8[:, :, :], f8[:, :, :], f8, f8, f8, f8, f8, f8, f8)"
+    "f8[:, :](f8[:], f8[:], f8[:], f8[:, :, :], f8[:, :, :], f8[:, :, :], f8, f8, f8, f8, f8, f8, f8, b1)"
 )
-def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, stepsize):
+def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, stepsize, honor_grid):
     """Perform a posteriori 3D ray-tracing."""
     condz = z[0] <= zend <= z[-1]
     condx = x[0] <= xend <= x[-1]
@@ -16,7 +17,20 @@ def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, ste
     if not (condz and condx and condy):
         raise ValueError("end point out of bound")
 
+    if honor_grid:
+        nz, nx, ny = len(z), len(x), len(y)
+
+        i = numpy.nonzero(z <= zend)[0][-1]
+        j = numpy.nonzero(x <= xend)[0][-1]
+        k = numpy.nonzero(y <= yend)[0][-1]
+        zmin = z[max(i - 1, 0)] if zend == z[i] else z[i]
+        xmin = x[max(j - 1, 0)] if xend == x[j] else x[j]
+        ymin = y[max(k - 1, 0)] if yend == y[k] else y[k]
+        lower = numpy.array([zmin, xmin, ymin])
+        upper = numpy.array([z[min(i + 1, nz - 1)], x[min(j + 1, nx - 1)], y[min(k + 1, ny - 1)]])
+
     pcur = numpy.array([zend, xend, yend], dtype=numpy.float64)
+    delta = numpy.empty(3, dtype=numpy.float64)
     ray = [pcur.copy()]
     while dist3d(zsrc, xsrc, ysrc, pcur[0], pcur[1], pcur[2]) > stepsize:
         gz = interp3d(z, x, y, zgrad, pcur)
@@ -29,12 +43,32 @@ def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, ste
         else:
             break
 
-        pcur[0] -= stepsize * gz * gni
-        pcur[1] -= stepsize * gx * gni
-        pcur[2] -= stepsize * gy * gni
-        ray.append(pcur.copy())
-    ray.append(numpy.array([zsrc, xsrc, ysrc], dtype=numpy.float64))
+        delta[0] = stepsize * gz * gni
+        delta[1] = stepsize * gx * gni
+        delta[2] = stepsize * gy * gni
 
+        if honor_grid:
+            fac = shrink(pcur, delta, lower, upper)
+            pcur -= fac * delta
+
+            if fac < 1.0:
+                i = numpy.nonzero(z <= pcur[0])[0][-1]
+                j = numpy.nonzero(x <= pcur[1])[0][-1]
+                k = numpy.nonzero(y <= pcur[2])[0][-1]
+                lower[0] = z[max(i - 1, 0)] if pcur[0] == z[i] else z[i]
+                lower[1] = x[max(j - 1, 0)] if pcur[1] == x[j] else x[j]
+                lower[2] = y[max(k - 1, 0)] if pcur[2] == y[k] else y[k]
+                upper[0] = z[i + 1]
+                upper[1] = x[j + 1]
+                upper[2] = y[k + 1]
+
+                ray.append(pcur.copy())
+
+        else:
+            pcur -= delta
+            ray.append(pcur.copy())
+
+    ray.append(numpy.array([zsrc, xsrc, ysrc], dtype=numpy.float64))
     out = numpy.empty((len(ray), 3), dtype=numpy.float64)
     for i, r in enumerate(ray):
         out[-i - 1] = r
@@ -44,7 +78,7 @@ def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, ste
 
 @jitted(parallel=True)
 def _ray3d_vectorized(
-    z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, stepsize
+    z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, stepsize, honor_grid=False,
 ):
     """Perform ray-tracing in parallel for different points."""
     out = []
@@ -64,6 +98,7 @@ def _ray3d_vectorized(
                 xsrc,
                 ysrc,
                 stepsize,
+                honor_grid,
             )
         )
 
@@ -71,7 +106,7 @@ def _ray3d_vectorized(
 
 
 @jitted
-def ray3d(z, x, y, zgrad, xgrad, ygrad, p, src, stepsize):
+def ray3d(z, x, y, zgrad, xgrad, ygrad, p, src, stepsize, honor_grid=False):
     """Perform ray-tracing."""
     if p.ndim == 1:
         return _ray3d(
@@ -88,6 +123,7 @@ def ray3d(z, x, y, zgrad, xgrad, ygrad, p, src, stepsize):
             src[1],
             src[2],
             stepsize,
+            honor_grid,
         )
 
     else:
@@ -105,4 +141,5 @@ def ray3d(z, x, y, zgrad, xgrad, ygrad, p, src, stepsize):
             src[1],
             src[2],
             stepsize,
+            honor_grid,
         )

--- a/fteikpy/_fteik/_ray3d.py
+++ b/fteikpy/_fteik/_ray3d.py
@@ -1,15 +1,30 @@
 import numpy
 from numba import prange
 
-from ._common import first_index, shrink
 from .._common import dist3d, jitted, norm3d
 from .._interp import interp3d
+from ._common import first_index, shrink
 
 
 @jitted(
     "f8[:, :](f8[:], f8[:], f8[:], f8[:, :, :], f8[:, :, :], f8[:, :, :], f8, f8, f8, f8, f8, f8, f8, b1)"
 )
-def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, stepsize, honor_grid):
+def _ray3d(
+    z,
+    x,
+    y,
+    zgrad,
+    xgrad,
+    ygrad,
+    zend,
+    xend,
+    yend,
+    zsrc,
+    xsrc,
+    ysrc,
+    stepsize,
+    honor_grid,
+):
     """Perform a posteriori 3D ray-tracing."""
     condz = z[0] <= zend <= z[-1]
     condx = x[0] <= xend <= x[-1]
@@ -27,7 +42,9 @@ def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, ste
         xmin = x[max(j - 1, 0)] if xend == x[j] else x[j]
         ymin = y[max(k - 1, 0)] if yend == y[k] else y[k]
         lower = numpy.array([zmin, xmin, ymin])
-        upper = numpy.array([z[min(i + 1, nz - 1)], x[min(j + 1, nx - 1)], y[min(k + 1, ny - 1)]])
+        upper = numpy.array(
+            [z[min(i + 1, nz - 1)], x[min(j + 1, nx - 1)], y[min(k + 1, ny - 1)]]
+        )
 
     pcur = numpy.array([zend, xend, yend], dtype=numpy.float64)
     delta = numpy.empty(3, dtype=numpy.float64)
@@ -78,7 +95,20 @@ def _ray3d(z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, ste
 
 @jitted(parallel=True)
 def _ray3d_vectorized(
-    z, x, y, zgrad, xgrad, ygrad, zend, xend, yend, zsrc, xsrc, ysrc, stepsize, honor_grid=False,
+    z,
+    x,
+    y,
+    zgrad,
+    xgrad,
+    ygrad,
+    zend,
+    xend,
+    yend,
+    zsrc,
+    xsrc,
+    ysrc,
+    stepsize,
+    honor_grid=False,
 ):
     """Perform ray-tracing in parallel for different points."""
     out = []

--- a/fteikpy/_grid.py
+++ b/fteikpy/_grid.py
@@ -98,7 +98,7 @@ class TraveltimeGrid2D(BaseGrid2D, BaseTraveltime):
             fill_value,
         )
 
-    def raytrace(self, points, stepsize=None):
+    def raytrace(self, points, stepsize=None, honor_grid=False):
         """
         2D a posteriori ray-tracing.
 
@@ -108,6 +108,8 @@ class TraveltimeGrid2D(BaseGrid2D, BaseTraveltime):
             Query point coordinates or list of point coordinates.
         stepsize : scalar or None, optional, default None
             Unit length of ray.
+        honor_grid : bool, optional, default False
+            If `True`, coordinates of raypaths are calculated with respect to traveltime grid discretization. `stepsize` might not be honored.
 
         Returns
         -------
@@ -126,6 +128,7 @@ class TraveltimeGrid2D(BaseGrid2D, BaseTraveltime):
             numpy.asarray(points, dtype=numpy.float64),
             self._source,
             stepsize,
+            honor_grid,
         )
 
     @property

--- a/fteikpy/_grid.py
+++ b/fteikpy/_grid.py
@@ -205,7 +205,7 @@ class TraveltimeGrid3D(BaseGrid3D, BaseTraveltime):
             fill_value,
         )
 
-    def raytrace(self, points, stepsize=None):
+    def raytrace(self, points, stepsize=None, honor_grid=False):
         """
         3D a posteriori ray-tracing.
 
@@ -215,6 +215,8 @@ class TraveltimeGrid3D(BaseGrid3D, BaseTraveltime):
             Query point coordinates or list of point coordinates.
         stepsize : scalar or None, optional, default None
             Unit length of ray.
+        honor_grid : bool, optional, default False
+            If `True`, coordinates of raypaths are calculated with respect to traveltime grid discretization. `stepsize` might not be honored.
 
         Returns
         -------
@@ -235,6 +237,7 @@ class TraveltimeGrid3D(BaseGrid3D, BaseTraveltime):
             numpy.asarray(points, dtype=numpy.float64),
             self._source,
             stepsize,
+            honor_grid,
         )
 
     @property

--- a/fteikpy/_interp/_interp2d.py
+++ b/fteikpy/_interp/_interp2d.py
@@ -16,8 +16,8 @@ def _interp2d(x, y, v, xq, yq, fval):
     nx -= 1
     ny -= 1
 
-    i1 = numpy.nonzero(x <= xq)[0][-1]
-    j1 = numpy.nonzero(y <= yq)[0][-1]
+    i1 = numpy.searchsorted(x, xq, side="right") - 1
+    j1 = numpy.searchsorted(y, yq, side="right") - 1
     i2 = i1 + 1
     j2 = j1 + 1
 

--- a/fteikpy/_interp/_interp2d.py
+++ b/fteikpy/_interp/_interp2d.py
@@ -65,11 +65,11 @@ def _interp2d(x, y, v, xq, yq, fval):
         v12 = v[i1, j2]
         v22 = v[i2, j2]
 
-    ax = numpy.array([x2, x1, x2, x1])
-    ay = numpy.array([y2, y2, y1, y1])
-    av = numpy.array([v11, v21, v12, v22])
-    N = numpy.abs((ax - xq) * (ay - yq)) / numpy.abs((x2 - x1) * (y2 - y1))
-    vq = numpy.dot(av, N)
+    vq = v11 * numpy.abs((x2 - xq) * (y2 - yq))
+    vq += v21 * numpy.abs((x1 - xq) * (y2 - yq))
+    vq += v12 * numpy.abs((x2 - xq) * (y1 - yq))
+    vq += v22 * numpy.abs((x1 - xq) * (y1 - yq))
+    vq /= numpy.abs((x2 - x1) * (y2 - y1))
 
     return vq
 

--- a/fteikpy/_interp/_interp3d.py
+++ b/fteikpy/_interp/_interp3d.py
@@ -18,9 +18,9 @@ def _interp3d(x, y, z, v, xq, yq, zq, fval):
     ny -= 1
     nz -= 1
 
-    i1 = numpy.nonzero(x <= xq)[0][-1]
-    j1 = numpy.nonzero(y <= yq)[0][-1]
-    k1 = numpy.nonzero(z <= zq)[0][-1]
+    i1 = numpy.searchsorted(x, xq, side="right") - 1
+    j1 = numpy.searchsorted(y, yq, side="right") - 1
+    k1 = numpy.searchsorted(z, zq, side="right") - 1
     i2 = i1 + 1
     j2 = j1 + 1
     k2 = k1 + 1

--- a/fteikpy/_interp/_interp3d.py
+++ b/fteikpy/_interp/_interp3d.py
@@ -161,14 +161,15 @@ def _interp3d(x, y, z, v, xq, yq, zq, fval):
         v122 = v[i1, j2, k2]
         v222 = v[i2, j2, k2]
 
-    ax = numpy.array([x2, x1, x2, x1, x2, x1, x2, x1])
-    ay = numpy.array([y2, y2, y1, y1, y2, y2, y1, y1])
-    az = numpy.array([z2, z2, z2, z2, z1, z1, z1, z1])
-    av = numpy.array([v111, v211, v121, v221, v112, v212, v122, v222])
-    N = numpy.abs((ax - xq) * (ay - yq) * (az - zq)) / numpy.abs(
-        (x2 - x1) * (y2 - y1) * (z2 - z1)
-    )
-    vq = numpy.dot(av, N)
+    vq = v111 * numpy.abs((x2 - xq) * (y2 - yq) * (z2 - zq))
+    vq += v211 * numpy.abs((x1 - xq) * (y2 - yq) * (z2 - zq))
+    vq += v121 * numpy.abs((x2 - xq) * (y1 - yq) * (z2 - zq))
+    vq += v221 * numpy.abs((x1 - xq) * (y1 - yq) * (z2 - zq))
+    vq += v112 * numpy.abs((x2 - xq) * (y2 - yq) * (z1 - zq))
+    vq += v212 * numpy.abs((x1 - xq) * (y2 - yq) * (z1 - zq))
+    vq += v122 * numpy.abs((x2 - xq) * (y1 - yq) * (z1 - zq))
+    vq += v222 * numpy.abs((x1 - xq) * (y1 - yq) * (z1 - zq))
+    vq /= numpy.abs((x2 - x1) * (y2 - y1) * (z2 - z1))
 
     return vq
 

--- a/fteikpy/_interp/_vinterp2d.py
+++ b/fteikpy/_interp/_vinterp2d.py
@@ -11,11 +11,11 @@ def _vinterp2d(x, y, v, xq, yq, xsrc, ysrc, vzero, fval):
     condy = y[0] <= yq <= y[-1]
     if not (condx and condy):
         return fval
-
-    xsi = numpy.nonzero(x <= xsrc)[0][-1]
-    ysi = numpy.nonzero(y <= ysrc)[0][-1]
-    i1 = numpy.nonzero(x <= xq)[0][-1]
-    j1 = numpy.nonzero(y <= yq)[0][-1]
+    
+    xsi = numpy.searchsorted(x, xsrc, side="right") - 1
+    ysi = numpy.searchsorted(y, ysrc, side="right") - 1
+    i1 = numpy.searchsorted(x, xq, side="right") - 1
+    j1 = numpy.searchsorted(y, yq, side="right") - 1
 
     if xsi == i1 and ysi == j1:
         vq = vzero * dist2d(xsrc, ysrc, xq, yq)

--- a/fteikpy/_interp/_vinterp2d.py
+++ b/fteikpy/_interp/_vinterp2d.py
@@ -91,12 +91,12 @@ def _vinterp2d(x, y, v, xq, yq, xsrc, ysrc, vzero, fval):
             v12 = v[i1, j2]
             v22 = v[i2, j2]
 
-        ax = numpy.array([x2, x1, x2, x1])
-        ay = numpy.array([y2, y2, y1, y1])
-        av = numpy.array([v11, v21, v12, v22])
-        ad = numpy.array([d11, d21, d12, d22])
-        N = numpy.abs((ax - xq) * (ay - yq)) / numpy.abs((x2 - x1) * (y2 - y1))
-        vq = dist2d(xsrc, ysrc, xq, yq) / numpy.dot(ad / av, N)
+        vq = d11 / v11 * numpy.abs((x2 - xq) * (y2 - yq))
+        vq += d21 / v21 * numpy.abs((x1 - xq) * (y2 - yq))
+        vq += d12 / v12 * numpy.abs((x2 - xq) * (y1 - yq))
+        vq += d22 / v22 * numpy.abs((x1 - xq) * (y1 - yq))
+        vq /= numpy.abs((x2 - x1) * (y2 - y1))
+        vq = dist2d(xsrc, ysrc, xq, yq) / vq
 
     return vq
 

--- a/fteikpy/_interp/_vinterp2d.py
+++ b/fteikpy/_interp/_vinterp2d.py
@@ -11,7 +11,7 @@ def _vinterp2d(x, y, v, xq, yq, xsrc, ysrc, vzero, fval):
     condy = y[0] <= yq <= y[-1]
     if not (condx and condy):
         return fval
-    
+
     xsi = numpy.searchsorted(x, xsrc, side="right") - 1
     ysi = numpy.searchsorted(y, ysrc, side="right") - 1
     i1 = numpy.searchsorted(x, xq, side="right") - 1

--- a/fteikpy/_interp/_vinterp3d.py
+++ b/fteikpy/_interp/_vinterp3d.py
@@ -13,12 +13,12 @@ def _vinterp3d(x, y, z, v, xq, yq, zq, xsrc, ysrc, zsrc, vzero, fval):
     if not (condx and condy and condz):
         return fval
 
-    xsi = numpy.nonzero(x <= xsrc)[0][-1]
-    ysi = numpy.nonzero(y <= ysrc)[0][-1]
-    zsi = numpy.nonzero(z <= zsrc)[0][-1]
-    i1 = numpy.nonzero(x <= xq)[0][-1]
-    j1 = numpy.nonzero(y <= yq)[0][-1]
-    k1 = numpy.nonzero(z <= zq)[0][-1]
+    xsi = numpy.searchsorted(x, xsrc, side="right") - 1
+    ysi = numpy.searchsorted(y, ysrc, side="right") - 1
+    zsi = numpy.searchsorted(z, zsrc, side="right") - 1
+    i1 = numpy.searchsorted(x, xq, side="right") - 1
+    j1 = numpy.searchsorted(y, yq, side="right") - 1
+    k1 = numpy.searchsorted(z, zq, side="right") - 1
 
     if xsi == i1 and ysi == j1 and zsi == k1:
         vq = vzero * dist3d(xsrc, ysrc, zsrc, xq, yq, zq)

--- a/fteikpy/_interp/_vinterp3d.py
+++ b/fteikpy/_interp/_vinterp3d.py
@@ -240,15 +240,16 @@ def _vinterp3d(x, y, z, v, xq, yq, zq, xsrc, ysrc, zsrc, vzero, fval):
             v122 = v[i1, j2, k2]
             v222 = v[i2, j2, k2]
 
-        ax = numpy.array([x2, x1, x2, x1, x2, x1, x2, x1])
-        ay = numpy.array([y2, y2, y1, y1, y2, y2, y1, y1])
-        az = numpy.array([z2, z2, z2, z2, z1, z1, z1, z1])
-        av = numpy.array([v111, v211, v121, v221, v112, v212, v122, v222])
-        ad = numpy.array([d111, d211, d121, d221, d112, d212, d122, d222])
-        N = numpy.abs((ax - xq) * (ay - yq) * (az - zq)) / numpy.abs(
-            (x2 - x1) * (y2 - y1) * (z2 - z1)
-        )
-        vq = dist3d(xsrc, ysrc, zsrc, xq, yq, zq) / numpy.dot(ad / av, N)
+        vq = d111 / v111 * numpy.abs((x2 - xq) * (y2 - yq) * (z2 - zq))
+        vq += d211 / v211 * numpy.abs((x1 - xq) * (y2 - yq) * (z2 - zq))
+        vq += d121 / v121 * numpy.abs((x2 - xq) * (y1 - yq) * (z2 - zq))
+        vq += d221 / v221 * numpy.abs((x1 - xq) * (y1 - yq) * (z2 - zq))
+        vq += d112 / v112 * numpy.abs((x2 - xq) * (y2 - yq) * (z1 - zq))
+        vq += d212 / v212 * numpy.abs((x1 - xq) * (y2 - yq) * (z1 - zq))
+        vq += d122 / v122 * numpy.abs((x2 - xq) * (y1 - yq) * (z1 - zq))
+        vq += d222 / v222 * numpy.abs((x1 - xq) * (y1 - yq) * (z1 - zq))
+        vq /= numpy.abs((x2 - x1) * (y2 - y1) * (z2 - z1))
+        vq = dist3d(xsrc, ysrc, zsrc, xq, yq, zq) / vq
 
     return vq
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fteikpy
-version = 2.0.1
+version = 2.1.0
 author = Keurfon Luu
 email = keurfonluu@outlook.com
 description = Accurate Eikonal solver for Python

--- a/test/test_traveltime2d.py
+++ b/test/test_traveltime2d.py
@@ -29,16 +29,20 @@ def test_call(points, tref):
 
 
 @pytest.mark.parametrize(
-    "points, pref",
+    "points, pref, honor_grid",
     (
-        ([0.5, 0.5], 1.0),
-        ([1.5, 1.5], 4.75735931),
-        ([[0.5, 0.5], [1.5, 1.5]], [1.0, 4.75735931]),
+        ([0.5, 0.5], 1.0, False),
+        ([0.5, 0.5], 1.0, True),
+        ([1.5, 1.5], 4.75735931, False),
+        ([1.5, 1.5], 5.0, True),
+        ([[0.5, 0.5], [1.5, 1.5]], [1.0, 4.75735931], False),
+        ([[0.5, 0.5], [1.5, 1.5]], [1.0, 5.0], True),
     ),
 )
-def test_raytrace(points, pref):
+def test_raytrace(points, pref, honor_grid):
     sources = 0.0, 0.0
     tt = eik2d.solve(sources, nsweep=2, return_gradient=True)
-    rays = tt.raytrace(points, stepsize=1.0)
+    rays = tt.raytrace(points, stepsize=1.0, honor_grid=honor_grid)
+    print(rays)
 
     allclose(pref, rays, lambda x: x.sum())

--- a/test/test_traveltime3d.py
+++ b/test/test_traveltime3d.py
@@ -33,16 +33,19 @@ def test_call(points, tref):
 
 
 @pytest.mark.parametrize(
-    "points, pref",
+    "points, pref, honor_grid",
     (
-        ([0.5, 0.5, 0.5], 1.5),
-        ([1.5, 1.5, 1.5], 8.30384757),
-        ([[0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [1.5, 8.30384757]),
+        ([0.5, 0.5, 0.5], 1.5, False),
+        ([0.5, 0.5, 0.5], 1.5, True),
+        ([1.5, 1.5, 1.5], 8.30384757, False),
+        ([1.5, 1.5, 1.5], 7.5, True),
+        ([[0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [1.5, 8.30384757], False),
+        ([[0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [1.5, 7.5], True),
     ),
 )
-def test_raytrace(points, pref):
+def test_raytrace(points, pref, honor_grid):
     sources = 0.0, 0.0, 0.0
     tt = eik3d.solve(sources, nsweep=3, return_gradient=True)
-    rays = tt.raytrace(points, stepsize=1.0)
+    rays = tt.raytrace(points, stepsize=1.0, honor_grid=honor_grid)
 
     allclose(pref, rays, lambda x: x.sum())


### PR DESCRIPTION
- Added: option to honor grid to method `raytracing`. This should facilitate building the Jacobian matrix (see issue #5),
- Fixed: raytracing outputs are now correctly ordered (`append` doesn't work *as expected* in parallel),
- Changed: unroll loops in interpolation functions which speeds up the code thanks to no array allocation.

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
