### PR TITLE
Raise error when infinite loop in raytracing

### DIFF
--- a/fteikpy/_fteik/_ray2d.py
+++ b/fteikpy/_fteik/_ray2d.py
@@ -27,6 +27,7 @@ def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid):
         isrc = numpy.searchsorted(z, zsrc, side="right") - 1
         jsrc = numpy.searchsorted(x, xsrc, side="right") - 1
 
+    count = 1
     pcur = numpy.array([zend, xend], dtype=numpy.float64)
     delta = numpy.empty(2, dtype=numpy.float64)
     ray = [pcur.copy()]
@@ -71,6 +72,12 @@ def _ray2d(z, x, zgrad, xgrad, zend, xend, zsrc, xsrc, stepsize, honor_grid):
         else:
             pcur -= delta
             ray.append(pcur.copy())
+
+        # Fix a conservative maximum number of steps to avoid infinite loop
+        # (can happen when using return_gradient=False)
+        count += 1
+        if count >= 99999:
+            raise RuntimeError("maximum number of steps reached")
 
     ray.append(numpy.array([zsrc, xsrc], dtype=numpy.float64))
     out = numpy.empty((len(ray), 2), dtype=numpy.float64)

--- a/fteikpy/_fteik/_ray3d.py
+++ b/fteikpy/_fteik/_ray3d.py
@@ -50,6 +50,7 @@ def _ray3d(
         jsrc = numpy.searchsorted(x, xsrc, side="right") - 1
         ksrc = numpy.searchsorted(y, ysrc, side="right") - 1
 
+    count = 1
     pcur = numpy.array([zend, xend, yend], dtype=numpy.float64)
     delta = numpy.empty(3, dtype=numpy.float64)
     ray = [pcur.copy()]
@@ -100,6 +101,12 @@ def _ray3d(
         else:
             pcur -= delta
             ray.append(pcur.copy())
+
+        # Fix a conservative maximum number of steps to avoid infinite loop
+        # (can happen when using return_gradient=False)
+        count += 1
+        if count >= 99999:
+            raise RuntimeError("maximum number of steps reached")
 
     ray.append(numpy.array([zsrc, xsrc, ysrc], dtype=numpy.float64))
     out = numpy.empty((len(ray), 3), dtype=numpy.float64)

--- a/fteikpy/_solver.py
+++ b/fteikpy/_solver.py
@@ -37,7 +37,7 @@ class Eikonal2D(BaseGrid2D):
         nsweep : int, optional, default 2
             Number of sweeps.
         return_gradient : bool, optional, default False
-            If `True`, directions of gradient are computed at runtime which yield more accurate gradient especially at the edges of the grid. However, this option uses more memory as the gradient grid is saved. Otherwise, gradient is estimated using :func:`numpy.gradient`.
+            If `True`, directions of gradient are computed at runtime which yield more accurate gradient especially at the edges of the grid. However, this option uses more memory as the gradient grid is saved. Otherwise, gradient is estimated using :func:`numpy.gradient`. It is recommended to enable this option for a posteriori raytracing.
 
         Returns
         -------
@@ -109,7 +109,7 @@ class Eikonal3D(BaseGrid3D):
         nsweep : int, optional, default 2
             Number of sweeps.
         return_gradient : bool, optional, default False
-            If `True`, directions of gradient are computed at runtime which yield more accurate gradient especially at the edges of the grid. However, this option uses more memory as the gradient grid is saved. Otherwise, gradient is estimated using :func:`numpy.gradient`.
+            If `True`, directions of gradient are computed at runtime which yield more accurate gradient especially at the edges of the grid. However, this option uses more memory as the gradient grid is saved. Otherwise, gradient is estimated using :func:`numpy.gradient`. It is recommended to enable this option for a posteriori raytracing.
 
         Returns
         -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fteikpy
-version = 2.2.0
+version = 2.2.1
 author = Keurfon Luu
 email = keurfonluu@outlook.com
 description = Accurate Eikonal solver for Python


### PR DESCRIPTION
- Raise runtime error when infinite loop detected in raytracing (may happen when `return_gradient=False`),
- Recommend option `return_gradient` in doc if traveltime gradient grid is needed (e.g., raytracing, incident angle...).

**Reminders**:

-   [x] Run `invoke format` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
